### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: php
 dist: trusty
 php:
-  - '5.6'
   - '7.0'
   - '7.1'
+  - '7.2'
+  - nightly
   - 'hhvm'
+matrix:
+  allow_failures:
+    - php: nightly
 install:
   - composer update
 script:

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^6.5",
         "satooshi/php-coveralls": "^2.0"
     },
     "autoload": {
@@ -20,8 +20,14 @@
             "src/IsOffensiveFunction.php"
         ]
     },
+    "autoload-dev": {
+        "psr-4": {
+            "DivineOmega\\IsOffensive\\Tests\\": "tests/"
+        }
+    },
     "license": "LGPL-3.0-only",
     "require": {
+        "php": ">=7.0",
         "snipe/banbuilder": "^2.2.5"
     }
 }

--- a/tests/Unit/CustomListsTest.php
+++ b/tests/Unit/CustomListsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace DivineOmega\IsOffensive\Tests;
+
 use DivineOmega\IsOffensive\OffensiveChecker;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Unit/FalsePositiveTextsTest.php
+++ b/tests/Unit/FalsePositiveTextsTest.php
@@ -1,16 +1,30 @@
 <?php
 
+namespace DivineOmega\IsOffensive\Tests;
+
 use PHPUnit\Framework\TestCase;
 
 class FalsePositiveTextsTest extends TestCase
 {
-    public function testForFalsePositivesInTexts()
+    public function forFalsePositivesInTextsProvider()
     {
         $files = glob(__DIR__.'/texts/*.txt');
+        $dataProvider = [];
 
         foreach ($files as $file) {
-            $content = file_get_contents($file);
-            $this->assertFalse(is_offensive($content));
+            $dataProvider[] = [$file];
         }
+
+        return $dataProvider;
+    }
+
+    /**
+     * @dataProvider forFalsePositivesInTextsProvider
+     */
+    public function testForFalsePositivesInTexts($file)
+    {
+        $content = file_get_contents($file);
+
+        $this->assertFalse(is_offensive($content));
     }
 }

--- a/tests/Unit/IsOffensiveTest.php
+++ b/tests/Unit/IsOffensiveTest.php
@@ -1,33 +1,67 @@
 <?php
 
+namespace DivineOmega\IsOffensive\Tests;
+
 use PHPUnit\Framework\TestCase;
 
 class IsOffensiveTest extends TestCase
 {
-    public function testIfOffensive()
+    public function ifOffensiveProvider()
     {
-        $words = ['fuck', 'fuk', 'fuker', 'motherfucker', 'mutherfuker', 'cunt', 'tit'];
-
-        foreach ($words as $word) {
-            $this->assertTrue(is_offensive($word));
-        }
+        return [
+            ['fuck'],
+            ['fuk'],
+            ['fuker'],
+            ['motherfucker'],
+            ['mutherfuker'],
+            ['cunt'],
+            ['tit'],
+        ];
     }
 
-    public function testIfNotOffensive()
+    /**
+     * @dataProvider ifOffensiveProvider
+     */
+    public function testIfOffensive($word)
     {
-        $words = ['duck', 'cat', 'greetings', 'cheese'];
-
-        foreach ($words as $word) {
-            $this->assertFalse(is_offensive($word));
-        }
+        $this->assertTrue(is_offensive($word));
     }
 
-    public function testWhitelistedWords()
+    public function ifNotOffensiveProvider()
     {
-        $words = ['hello', 'Hello', 'HELLO', 'middlesex', 'tittesworth', 'scunthorpe'];
+        return [
+            ['duck'],
+            ['cat'],
+            ['greetings'],
+            ['cheese'],
+        ];
+    }
 
-        foreach ($words as $word) {
-            $this->assertFalse(is_offensive($word));
-        }
+    /**
+     * @dataProvider ifNotOffensiveProvider
+     */
+    public function testIfNotOffensive($word)
+    {
+        $this->assertFalse(is_offensive($word));
+    }
+
+    public function whitelistedWordsProvider()
+    {
+        return [
+            ['hello'],
+            ['Hello'],
+            ['HELLO'],
+            ['middlesex'],
+            ['tittesworth'],
+            ['scunthorpe'],
+        ];
+    }
+
+    /**
+     * @dataProvider whitelistedWordsProvider
+     */
+    public function testWhitelistedWords($word)
+    {
+        $this->assertFalse(is_offensive($word));
     }
 }


### PR DESCRIPTION
# Changed log

- It's time to remove `php-5.6` in Travis CI build.
- Using PHPUnit `DataProvider` feature to collect the test cases and separate this from related test methods.
- Upgrade the PHPUnit version to `^6.5` and it can support latest/stable PHP versions.