### PR TITLE
Test improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 composer.lock
 vendor
+*.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
 language: php
 dist: trusty
 php:
-  - '7.0'
   - '7.1'
   - '7.2'
+  - '7.3'
+  - '7.4'
   - nightly
-  - 'hhvm'
 matrix:
   allow_failures:
     - php: nightly
 install:
-  - composer update
+  - composer install
 script:
  - ./vendor/bin/phpunit --coverage-clover ./tests/Logs/clover.xml
 after_script:

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
         }
     ],
     "require-dev": {
-        "phpunit/phpunit": "^6.5",
-        "satooshi/php-coveralls": "^2.0"
+        "phpunit/phpunit": "^7.0 || ^8.0",
+        "php-coveralls/php-coveralls": "^2.0"
     },
     "autoload": {
         "psr-4": {
@@ -22,12 +22,12 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "DivineOmega\\IsOffensive\\Tests\\": "tests/"
+            "DivineOmega\\IsOffensive\\Tests\\": "tests/Unit/"
         }
     },
     "license": "LGPL-3.0-only",
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.1",
         "snipe/banbuilder": "^2.2.5"
     }
 }


### PR DESCRIPTION
# Changed log
- Add `*.cache` file to ignore on Git version control.
- Add `php-7.3` and `php-7.4` version tests on Travis CI build.
- Using `composer install` on Travis CI build because the `composer.lock` is not under Git version control.
- Changing into `tests/Unit/` folder to load test classes automatically and it defined on `autoload-dev` block.
- The `satooshi/php-coveralls` package is deprecated and using `php-coveralls/php-coveralls` package instead.